### PR TITLE
Use generated token for actions/checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
         app-id: ${{ vars.APP_ID }}
         private-key: ${{ secrets.PRIVATE_KEY }}
     - uses: actions/checkout@v4
+      with:
+        token: ${{ steps.app-token.outputs.token }}
     - uses: Songmu/tagpr@v1
       env:
         GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
In release.yml actions/checkout was using github.token so instead make sure to use the generated token.