### PR TITLE
Add Associate wrapper function

### DIFF
--- a/godash.go
+++ b/godash.go
@@ -96,3 +96,7 @@ func NoneBy[T any](collection []T, predicate func(item T) bool) bool {
 func Find[T any](collection []T, predicate func(item T) bool) (T, bool) {
 	return lo.Find(collection, predicate)
 }
+
+func Associate[T any, K comparable, V any](collection []T, transform func(item T) (K, V)) map[K]V {
+	return lo.Associate(collection, transform)
+}

--- a/godash_test.go
+++ b/godash_test.go
@@ -218,3 +218,19 @@ func ExampleFind() {
 	}))
 	// Output: {bar 25} true
 }
+
+func ExampleAssociate() {
+	type User struct {
+		name string
+		age  int
+	}
+	users := []User{
+		{"foo", 20},
+		{"bar", 25},
+		{"baz", 40},
+	}
+	fmt.Println(godash.Associate(users, func(u User) (string, int) {
+		return u.name, u.age
+	}))
+	// Output: map[bar:25 baz:40 foo:20]
+}


### PR DESCRIPTION
I added `Associate` wrapper function.

before

```go
type Row struct {
    ID string
    Name string
}

m := make(map[string]*Row)
for _, r := range rows {
    m[r.ID] = r
}
```

after

```go
m := godash.Associate(rows, func(r *Row) (string, *Row) {
    return r.ID, r
})
```